### PR TITLE
Fix/clear cache on unmock

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -80,6 +80,10 @@ export interface EndpointGetFunction<TKeys extends {}, TResult extends unknown>
 	 */
 	getCacheKey: (keys: TKeys) => string;
 	/**
+	 * A cache store
+	 */
+	cache?: Cache<TResult>;
+	/**
 	 * Helper to prevent memory leaks
 	 *
 	 * Returns a clear cache function for the given keys

--- a/utils/request-registry-mobx/test/index.test.ts
+++ b/utils/request-registry-mobx/test/index.test.ts
@@ -131,7 +131,7 @@ describe('request-registry-mobx', () => {
 						'/user/1': { name: 'Sue', age: 24 },
 						'/user/2': { name: 'Joe', age: 18 },
 					}[(url as '/user/1') || '/user/2']),
-				1
+				50
 			);
 			const endpoint = createObservableEndpoint(userEndpoint, {
 				id: '1',

--- a/utils/request-registry-mock/src/index.ts
+++ b/utils/request-registry-mock/src/index.ts
@@ -213,6 +213,10 @@ export function mockEndpoint<
 	};
 	// Add the original mockFunction to find it during cleanup
 	baseMocks.set(endpoint.loader, mockResponse);
+	// Refresh previous caches if any exists
+	if ('refresh' in endpoint) {
+		(endpoint as EndpointGetFunction<any, any>).refresh();
+	}
 	// Return the dispose function
 	return unmockEndpoint.bind(null, endpoint, endpoint.loader);
 }

--- a/utils/request-registry-mock/src/index.ts
+++ b/utils/request-registry-mock/src/index.ts
@@ -239,6 +239,11 @@ function unmockEndpoint(
 		if (previousLoader) {
 			endpoint.loader = previousLoader;
 		}
+		// Make sure that further access to the endpoint will not
+		// be a cached version of this mock
+		if ('cache' in endpoint && endpoint.cache) {
+			endpoint.cache.clear();
+		}
 	} else if (loaderFunction === undefined) {
 		// If no loaderFunction was given Erase all loaders
 		const originalLoader = originalLoadersOfEndpoint.splice(0)[0];


### PR DESCRIPTION
Clearing cache after a mock is removed ensures that future calls don't return values created by the
mock